### PR TITLE
Add Tracks browser, alphabetic hierarchy for Albums/Artists/Tracks

### DIFF
--- a/custom_components/apple_music/browse_media.py
+++ b/custom_components/apple_music/browse_media.py
@@ -5,7 +5,10 @@ from urllib.parse import quote
 from homeassistant.components.media_player import BrowseMedia, MediaClass, MediaType
 from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.helpers.network import is_internal_request
-from .const import BROWSE_ALBUMS, BROWSE_ARTISTS, BROWSE_PLAYLISTS, BROWSE_ROOT, BROWSE_SEP
+from .const import (
+    BROWSE_ALBUMS, BROWSE_ARTISTS, BROWSE_PLAYLISTS,
+    BROWSE_ROOT, BROWSE_SEP, BROWSE_TRACKS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,16 +16,17 @@ def slugify(s): return re.sub(r'^-|-$', '', re.sub(r'[^a-z0-9]+', '-', s.lower()
 def parameterize(s): return slugify(s)
 def q(s): return quote(s, safe='')
 
+def _first_letter(name: str) -> str:
+    if not name:
+        return '#'
+    c = name.lstrip(' ').upper()[0]
+    return c if c.isalpha() else '#'
+
 def _thumb(hass, base_url, static_file, entity, mtype, cid):
-    """Return artwork URL.
-    Internal: direct /artwork-static/<file> — checks custom-artwork then artwork-cache.
-    External: proxied through HA using artwork-static as image_id so proxy
-              also benefits from custom-artwork priority."""
     if not entity:
         return None
     if is_internal_request(hass):
         return f"{base_url}/artwork-static/{static_file}"
-    # External: HA proxies via async_get_browse_image which fetches base_url/media_image_id
     return entity.get_browse_image_url(mtype, cid, media_image_id=f"artwork-static/{static_file}")
 
 def _node(title, mc, mt, cid, play, expand, children=None, thumbnail=None):
@@ -30,17 +34,34 @@ def _node(title, mc, mt, cid, play, expand, children=None, thumbnail=None):
                        media_content_id=cid, can_play=play, can_expand=expand,
                        children=children, thumbnail=thumbnail)
 
+def _track_cid(t, S):
+    """media_content_id für einen Track: track||id||artist||album"""
+    return f"track{S}{t.get('id','')}{S}{t.get('albumArtist') or t.get('artist','')}{S}{t.get('album','')}"
+
+def _track_thumb(t, hu, bu, entity, S):
+    """Artwork für einen Track aus albumArtist + album aufbauen."""
+    album  = t.get("album") or ""
+    artist = t.get("albumArtist") or t.get("artist") or ""
+    if not album:
+        return None
+    static_file = f"{slugify(artist + '||' + album)}.jpg"
+    cid = _track_cid(t, S)
+    return _thumb(hu, bu, static_file, entity, MediaType.TRACK, cid)
+
 async def async_browse_media(coordinator, media_content_type, media_content_id, entity=None):
     C, S = coordinator, BROWSE_SEP
     hu, bu = coordinator.hass, coordinator.base_url
 
+    # ── Root ──────────────────────────────────────────────────────────────────
     if not media_content_id or media_content_id == BROWSE_ROOT:
         return _node("Apple Music", MediaClass.DIRECTORY, MediaType.MUSIC, BROWSE_ROOT, False, True, [
             _node("Playlists", MediaClass.PLAYLIST, MediaType.PLAYLIST, BROWSE_PLAYLISTS, False, True),
             _node("Artists",   MediaClass.ARTIST,   MediaType.ARTIST,   BROWSE_ARTISTS,   False, True),
             _node("Albums",    MediaClass.ALBUM,     MediaType.ALBUM,    BROWSE_ALBUMS,    False, True),
+            _node("Tracks",    MediaClass.TRACK,     MediaType.TRACK,    BROWSE_TRACKS,    False, True),
         ])
 
+    # ── Playlists ─────────────────────────────────────────────────────────────
     if media_content_id == BROWSE_PLAYLISTS:
         data = await C.async_get("/playlists") or {}
         kids = [_node(pl["name"], MediaClass.PLAYLIST, MediaType.PLAYLIST,
@@ -50,21 +71,53 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
                                        entity, MediaType.PLAYLIST,
                                        f"playlist{S}{parameterize(pl['name'])}"))
                 for pl in data.get("playlists", [])]
-        return _node("Playlists", MediaClass.DIRECTORY, MediaType.PLAYLIST, BROWSE_PLAYLISTS, False, True, kids)
+        return _node("Playlists", MediaClass.DIRECTORY, MediaType.PLAYLIST,
+                     BROWSE_PLAYLISTS, False, True, kids)
 
+    # ── Artists — Buchstaben-Übersicht ────────────────────────────────────────
     if media_content_id == BROWSE_ARTISTS:
-        data = await C.async_get("/library/artists?offset=0&limit=2000") or {}
+        data = await C.async_get("/library/artists?offset=0&limit=5000") or {}
+        buckets: dict[str, list] = {}
+        for a in data.get("artists", []):
+            buckets.setdefault(_first_letter(a["name"]), []).append(a)
+        letters = sorted(l for l in buckets if l != '#') + (['#'] if '#' in buckets else [])
+        kids = [_node(f"{l} ({len(buckets[l])})", MediaClass.DIRECTORY, MediaType.ARTIST,
+                      f"artists_letter{S}{l}", False, True)
+                for l in letters]
+        return _node("Artists", MediaClass.DIRECTORY, MediaType.ARTIST,
+                     BROWSE_ARTISTS, False, True, kids)
+
+    # ── Artists — Einträge eines Buchstabens ──────────────────────────────────
+    if media_content_id.startswith(f"artists_letter{S}"):
+        letter = media_content_id[len(f"artists_letter{S}"):]
+        data = await C.async_get("/library/artists?offset=0&limit=5000") or {}
+        filtered = [a for a in data.get("artists", []) if _first_letter(a["name"]) == letter]
         kids = [_node(a["name"], MediaClass.ARTIST, MediaType.ARTIST,
                       f"artist{S}{a['name']}", True, True,
-                      thumbnail=_thumb(hu, bu,
-                                       f"artist-{slugify(a['name'])}.jpg",
-                                       entity, MediaType.ARTIST,
-                                       f"artist{S}{a['id']}"))
-                for a in data.get("artists", [])]
-        return _node("Artists", MediaClass.DIRECTORY, MediaType.ARTIST, BROWSE_ARTISTS, False, True, kids)
+                      thumbnail=_thumb(hu, bu, f"artist-{slugify(a['name'])}.jpg",
+                                       entity, MediaType.ARTIST, f"artist{S}{a['id']}"))
+                for a in filtered]
+        return _node(f"Artists — {letter}", MediaClass.DIRECTORY, MediaType.ARTIST,
+                     media_content_id, False, True, kids)
 
+    # ── Albums — Buchstaben-Übersicht ─────────────────────────────────────────
     if media_content_id == BROWSE_ALBUMS:
-        data = await C.async_get("/library/albums?offset=0&limit=2000") or {}
+        data = await C.async_get("/library/albums?offset=0&limit=10000") or {}
+        buckets: dict[str, list] = {}
+        for al in data.get("albums", []):
+            buckets.setdefault(_first_letter(al["name"]), []).append(al)
+        letters = sorted(l for l in buckets if l != '#') + (['#'] if '#' in buckets else [])
+        kids = [_node(f"{l} ({len(buckets[l])})", MediaClass.DIRECTORY, MediaType.ALBUM,
+                      f"albums_letter{S}{l}", False, True)
+                for l in letters]
+        return _node("Albums", MediaClass.DIRECTORY, MediaType.ALBUM,
+                     BROWSE_ALBUMS, False, True, kids)
+
+    # ── Albums — Einträge eines Buchstabens ───────────────────────────────────
+    if media_content_id.startswith(f"albums_letter{S}"):
+        letter = media_content_id[len(f"albums_letter{S}"):]
+        data = await C.async_get("/library/albums?offset=0&limit=10000") or {}
+        filtered = [al for al in data.get("albums", []) if _first_letter(al["name"]) == letter]
         kids = [_node(f"{al['name']} — {al['artist']}" if al.get("artist") else al["name"],
                       MediaClass.ALBUM, MediaType.ALBUM,
                       f"album{S}{al['artist']}{S}{al['name']}", True, True,
@@ -72,9 +125,38 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
                                        f"{slugify(al['artist'] + '||' + al['name'])}.jpg",
                                        entity, MediaType.ALBUM,
                                        f"album{S}{slugify(al['artist'])}{S}{al['id']}"))
-                for al in data.get("albums", [])]
-        return _node("Albums", MediaClass.DIRECTORY, MediaType.ALBUM, BROWSE_ALBUMS, False, True, kids)
+                for al in filtered]
+        return _node(f"Albums — {letter}", MediaClass.DIRECTORY, MediaType.ALBUM,
+                     media_content_id, False, True, kids)
 
+    # ── Tracks — Buchstaben-Übersicht ─────────────────────────────────────────
+    if media_content_id == BROWSE_TRACKS:
+        data_all = await C.async_get("/library/tracks?limit=99999") or {}
+        buckets: dict[str, list] = {}
+        for t in data_all.get("tracks", []):
+            buckets.setdefault(_first_letter(t["name"]), []).append(t)
+        total = data_all.get("total", 0)
+        letters = sorted(l for l in buckets if l != '#') + (['#'] if '#' in buckets else [])
+        kids = [_node(f"{l} ({len(buckets[l])})", MediaClass.DIRECTORY, MediaType.TRACK,
+                      f"tracks_letter{S}{l}", False, True)
+                for l in letters]
+        return _node(f"Tracks ({total})", MediaClass.DIRECTORY, MediaType.TRACK,
+                     BROWSE_TRACKS, False, True, kids)
+
+    # ── Tracks — Einträge eines Buchstabens ───────────────────────────────────
+    if media_content_id.startswith(f"tracks_letter{S}"):
+        letter = media_content_id[len(f"tracks_letter{S}"):]
+        data = await C.async_get(f"/library/tracks?letter={quote(letter, safe='')}&limit=2000") or {}
+        kids = [_node(
+                    f"{t['name']} — {t['artist']}" if t.get("artist") else t["name"],
+                    MediaClass.TRACK, MediaType.TRACK,
+                    _track_cid(t, S), True, False,
+                    thumbnail=_track_thumb(t, hu, bu, entity, S))
+                for t in data.get("tracks", [])]
+        return _node(f"Tracks — {letter}", MediaClass.DIRECTORY, MediaType.TRACK,
+                     media_content_id, False, True, kids)
+
+    # ── Artist → seine Alben ──────────────────────────────────────────────────
     parts = media_content_id.split(S)
 
     if parts[0] == "artist" and len(parts) == 2:
@@ -82,13 +164,14 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
         an = data.get("artist", parts[1])
         kids = [_node(al["name"], MediaClass.ALBUM, MediaType.ALBUM,
                       f"album{S}{an}{S}{al['name']}", True, True,
-                      thumbnail=_thumb(hu, bu,
-                                       f"{slugify(an + '||' + al['name'])}.jpg",
+                      thumbnail=_thumb(hu, bu, f"{slugify(an + '||' + al['name'])}.jpg",
                                        entity, MediaType.ALBUM,
                                        f"album{S}{slugify(an)}{S}{al['id']}"))
                 for al in data.get("albums", [])]
-        return _node(an, MediaClass.ARTIST, MediaType.ARTIST, f"artist{S}{an}", False, True, kids)
+        return _node(an, MediaClass.ARTIST, MediaType.ARTIST,
+                     f"artist{S}{an}", False, True, kids)
 
+    # ── Album → seine Tracks ──────────────────────────────────────────────────
     if parts[0] == "album" and len(parts) == 3:
         data = await C.async_get(f"/library/albums/{q(parts[1])}/{q(parts[2])}/tracks") or {}
         kids = [_node(t["name"], MediaClass.TRACK, MediaType.TRACK,

--- a/custom_components/apple_music/const.py
+++ b/custom_components/apple_music/const.py
@@ -1,21 +1,16 @@
 """Constants for the Apple Music integration."""
-
 DOMAIN = "apple_music"
-
 CONF_HOST = "host"
 CONF_PORT = "port"
-
 DEFAULT_PORT = 8181
 DEFAULT_NAME = "Apple Music"
-
 # How often HA polls the server for state
 SCAN_INTERVAL_SECONDS = 5
-
 # Media browser node identifiers
 BROWSE_ROOT       = "root"
 BROWSE_PLAYLISTS  = "playlists"
 BROWSE_ARTISTS    = "artists"
 BROWSE_ALBUMS     = "albums"
-
+BROWSE_TRACKS     = "tracks"
 # Separator used in browse media_content_id paths
 BROWSE_SEP = "||"

--- a/custom_components/apple_music/media_player.py
+++ b/custom_components/apple_music/media_player.py
@@ -183,8 +183,6 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
         return r if r in ("off", "all", "one") else "off"
 
     # ── Progress tracking ─────────────────────────────────────────────────────
-    # HA uses media_position + media_position_updated_at to interpolate the
-    # progress bar live between polls — no need to update every second.
 
     @property
     def media_position(self) -> float | None:
@@ -223,7 +221,6 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
         await self.coordinator.async_send_command("PUT", "/stop")
 
     async def async_media_next_track(self) -> None:
-        # Optimistically clear track info so UI shows loading state instantly
         self._optimistic_state("playing")
         await self.coordinator.async_send_command("PUT", "/next")
 
@@ -233,7 +230,6 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     async def async_set_volume_level(self, volume: float) -> None:
         self._optimistic_volume = float(volume)
-        # Patch coordinator data immediately so polls don't snap the slider back
         if self.coordinator.data:
             self.coordinator.data = dict(self.coordinator.data)
             self.coordinator.data["volume"] = int(volume * 100)
@@ -276,12 +272,14 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
             )
             await self.coordinator.async_request_refresh()
             return
+
         elif parts[0] == "playlist" and len(parts) == 2:
             await self.coordinator.async_send_command(
                 "PUT", f"/playlists/{parts[1]}/play"
             )
             await self.coordinator.async_request_refresh()
             return
+
         elif parts[0] == "album" and len(parts) == 3:
             artist_id = parts[1]
             album_id  = parts[2]
@@ -291,23 +289,15 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
             )
             await self.coordinator.async_request_refresh()
             return
-        elif parts[0] == "track" and len(parts) == 2:
-            # Optimistically update state so UI feels instant
-            track_id = parts[1]
-            current = dict(self.coordinator.data or {})
-            current["player_state"] = "playing"
-            current["id"] = track_id
-            current["player_position"] = 0
-            current["position_timestamp"] = None
-            self.coordinator.async_set_updated_data(current)
 
-            # Fire command without blocking — notify.py will push the real state via SSE
-            self.hass.async_create_task(
-                self.coordinator.async_send_command(
-                    "PUT", f"/library/tracks/{track_id}/play"
-                )
+        elif parts[0] == "track" and len(parts) >= 2:
+            track_id = parts[1]
+            await self.coordinator.async_send_command(
+                "PUT", f"/library/tracks/{track_id}/play"
             )
+            await self.coordinator.async_request_refresh()
             return
+
         else:
             _LOGGER.warning("Unrecognised media_id for play_media: %s", media_id)
             return
@@ -400,8 +390,6 @@ class AirPlaySpeaker(CoordinatorEntity, MediaPlayerEntity):
         return AIRPLAY_FEATURES
 
     def _get_device_data(self) -> dict | None:
-        """Find this speaker's current data from the coordinator's airplay cache."""
-        # AirPlay state is fetched separately; we store it as extra data on the coordinator
         return getattr(self.coordinator, "_airplay_devices", {}).get(self._device_id)
 
     @property
@@ -470,7 +458,6 @@ class AirPlaySpeaker(CoordinatorEntity, MediaPlayerEntity):
     async def async_set_volume_level(self, volume: float) -> None:
         volume = float(volume)
         self._optimistic_volume = volume
-        # Patch the coordinator cache immediately so polls don't snap the slider back
         devices = getattr(self.coordinator, "_airplay_devices", {})
         if self._device_id in devices:
             devices[self._device_id] = dict(devices[self._device_id])

--- a/server/app.js
+++ b/server/app.js
@@ -1268,6 +1268,33 @@ process.on('unhandledRejection', function(reason) {
   console.error('[unhandledRejection] Server kept alive:', reason);
 });
 
+app.get('/library/tracks', function(req, res) {
+  var offset = parseInt(req.query.offset) || 0;
+  var limit  = parseInt(req.query.limit)  || 100;
+  var letter = (req.query.letter || '').toUpperCase();
+  getLibraryTracks(function(error, tracks) {
+    if (error) { console.log(error); return res.sendStatus(500); }
+    var filtered = tracks;
+    if (letter) {
+      filtered = tracks.filter(function(t) {
+        if (!t.name) { return letter === '#'; }
+        var c = t.name.trim()[0].toUpperCase();
+        return letter === '#' ? !/[A-Z]/.test(c) : c === letter;
+      });
+    }
+    var sorted = filtered.slice().sort(function(a, b) {
+      return (a.name || '').toLowerCase().localeCompare((b.name || '').toLowerCase());
+    });
+    res.json({
+      total:  sorted.length,
+      offset: offset,
+      limit:  limit,
+      letter: letter || null,
+      tracks: sorted.slice(offset, offset + limit)
+    });
+  });
+});
+
 app.listen(process.env.PORT || 8181);
 
 getLibraryTracks(function(error, tracks) {


### PR DESCRIPTION
## Changes

- **New Tracks category** in the media browser root alongside Playlists/Artists/Albums
- **Alphabetic subfolder hierarchy** for Artists, Albums and Tracks — prevents 
  performance issues with large libraries (tested with 17,000+ tracks, 6,000+ albums)
- **Track artwork** displayed in the Tracks browser list

## How it works

- `const.py` — adds `BROWSE_TRACKS` constant
- `app.js` — adds `/library/tracks` endpoint with letter filtering and sorting
- `browse_media.py` — complete rewrite with alphabetic hierarchy for all categories
- `media_player.py` — track playback uses `async_request_refresh()` instead of 
  optimistic state update, ensuring correct cover art display