### PR TITLE
Feature/search

### DIFF
--- a/custom_components/apple_music/browse_media.py
+++ b/custom_components/apple_music/browse_media.py
@@ -5,7 +5,10 @@ from urllib.parse import quote
 from homeassistant.components.media_player import BrowseMedia, MediaClass, MediaType
 from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.helpers.network import is_internal_request
-from .const import BROWSE_ALBUMS, BROWSE_ARTISTS, BROWSE_PLAYLISTS, BROWSE_ROOT, BROWSE_SEP
+from .const import (
+    BROWSE_ALBUMS, BROWSE_ARTISTS, BROWSE_PLAYLISTS,
+    BROWSE_ROOT, BROWSE_SEP, BROWSE_TRACKS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,16 +16,17 @@ def slugify(s): return re.sub(r'^-|-$', '', re.sub(r'[^a-z0-9]+', '-', s.lower()
 def parameterize(s): return slugify(s)
 def q(s): return quote(s, safe='')
 
+def _first_letter(name: str) -> str:
+    if not name:
+        return '#'
+    c = name.lstrip(' ').upper()[0]
+    return c if c.isalpha() else '#'
+
 def _thumb(hass, base_url, static_file, entity, mtype, cid):
-    """Return artwork URL.
-    Internal: direct /artwork-static/<file> — checks custom-artwork then artwork-cache.
-    External: proxied through HA using artwork-static as image_id so proxy
-              also benefits from custom-artwork priority."""
     if not entity:
         return None
     if is_internal_request(hass):
         return f"{base_url}/artwork-static/{static_file}"
-    # External: HA proxies via async_get_browse_image which fetches base_url/media_image_id
     return entity.get_browse_image_url(mtype, cid, media_image_id=f"artwork-static/{static_file}")
 
 def _node(title, mc, mt, cid, play, expand, children=None, thumbnail=None):
@@ -30,17 +34,34 @@ def _node(title, mc, mt, cid, play, expand, children=None, thumbnail=None):
                        media_content_id=cid, can_play=play, can_expand=expand,
                        children=children, thumbnail=thumbnail)
 
+def _track_cid(t, S):
+    """media_content_id für einen Track: track||id||artist||album"""
+    return f"track{S}{t.get('id','')}{S}{t.get('albumArtist') or t.get('artist','')}{S}{t.get('album','')}"
+
+def _track_thumb(t, hu, bu, entity, S):
+    """Artwork für einen Track aus albumArtist + album aufbauen."""
+    album  = t.get("album") or ""
+    artist = t.get("albumArtist") or t.get("artist") or ""
+    if not album:
+        return None
+    static_file = f"{slugify(artist + '||' + album)}.jpg"
+    cid = _track_cid(t, S)
+    return _thumb(hu, bu, static_file, entity, MediaType.TRACK, cid)
+
 async def async_browse_media(coordinator, media_content_type, media_content_id, entity=None):
     C, S = coordinator, BROWSE_SEP
     hu, bu = coordinator.hass, coordinator.base_url
 
+    # ── Root ──────────────────────────────────────────────────────────────────
     if not media_content_id or media_content_id == BROWSE_ROOT:
         return _node("Apple Music", MediaClass.DIRECTORY, MediaType.MUSIC, BROWSE_ROOT, False, True, [
             _node("Playlists", MediaClass.PLAYLIST, MediaType.PLAYLIST, BROWSE_PLAYLISTS, False, True),
             _node("Artists",   MediaClass.ARTIST,   MediaType.ARTIST,   BROWSE_ARTISTS,   False, True),
             _node("Albums",    MediaClass.ALBUM,     MediaType.ALBUM,    BROWSE_ALBUMS,    False, True),
+            _node("Tracks",    MediaClass.TRACK,     MediaType.TRACK,    BROWSE_TRACKS,    False, True),
         ])
 
+    # ── Playlists ─────────────────────────────────────────────────────────────
     if media_content_id == BROWSE_PLAYLISTS:
         data = await C.async_get("/playlists") or {}
         kids = [_node(pl["name"], MediaClass.PLAYLIST, MediaType.PLAYLIST,
@@ -50,21 +71,53 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
                                        entity, MediaType.PLAYLIST,
                                        f"playlist{S}{parameterize(pl['name'])}"))
                 for pl in data.get("playlists", [])]
-        return _node("Playlists", MediaClass.DIRECTORY, MediaType.PLAYLIST, BROWSE_PLAYLISTS, False, True, kids)
+        return _node("Playlists", MediaClass.DIRECTORY, MediaType.PLAYLIST,
+                     BROWSE_PLAYLISTS, False, True, kids)
 
+    # ── Artists — Buchstaben-Übersicht ────────────────────────────────────────
     if media_content_id == BROWSE_ARTISTS:
-        data = await C.async_get("/library/artists?offset=0&limit=2000") or {}
+        data = await C.async_get("/library/artists?offset=0&limit=5000") or {}
+        buckets: dict[str, list] = {}
+        for a in data.get("artists", []):
+            buckets.setdefault(_first_letter(a["name"]), []).append(a)
+        letters = sorted(l for l in buckets if l != '#') + (['#'] if '#' in buckets else [])
+        kids = [_node(f"{l} ({len(buckets[l])})", MediaClass.DIRECTORY, MediaType.ARTIST,
+                      f"artists_letter{S}{l}", False, True)
+                for l in letters]
+        return _node("Artists", MediaClass.DIRECTORY, MediaType.ARTIST,
+                     BROWSE_ARTISTS, False, True, kids)
+
+    # ── Artists — Einträge eines Buchstabens ──────────────────────────────────
+    if media_content_id.startswith(f"artists_letter{S}"):
+        letter = media_content_id[len(f"artists_letter{S}"):]
+        data = await C.async_get("/library/artists?offset=0&limit=5000") or {}
+        filtered = [a for a in data.get("artists", []) if _first_letter(a["name"]) == letter]
         kids = [_node(a["name"], MediaClass.ARTIST, MediaType.ARTIST,
                       f"artist{S}{a['name']}", True, True,
-                      thumbnail=_thumb(hu, bu,
-                                       f"artist-{slugify(a['name'])}.jpg",
-                                       entity, MediaType.ARTIST,
-                                       f"artist{S}{a['id']}"))
-                for a in data.get("artists", [])]
-        return _node("Artists", MediaClass.DIRECTORY, MediaType.ARTIST, BROWSE_ARTISTS, False, True, kids)
+                      thumbnail=_thumb(hu, bu, f"artist-{slugify(a['name'])}.jpg",
+                                       entity, MediaType.ARTIST, f"artist{S}{a['id']}"))
+                for a in filtered]
+        return _node(f"Artists — {letter}", MediaClass.DIRECTORY, MediaType.ARTIST,
+                     media_content_id, False, True, kids)
 
+    # ── Albums — Buchstaben-Übersicht ─────────────────────────────────────────
     if media_content_id == BROWSE_ALBUMS:
-        data = await C.async_get("/library/albums?offset=0&limit=2000") or {}
+        data = await C.async_get("/library/albums?offset=0&limit=10000") or {}
+        buckets: dict[str, list] = {}
+        for al in data.get("albums", []):
+            buckets.setdefault(_first_letter(al["name"]), []).append(al)
+        letters = sorted(l for l in buckets if l != '#') + (['#'] if '#' in buckets else [])
+        kids = [_node(f"{l} ({len(buckets[l])})", MediaClass.DIRECTORY, MediaType.ALBUM,
+                      f"albums_letter{S}{l}", False, True)
+                for l in letters]
+        return _node("Albums", MediaClass.DIRECTORY, MediaType.ALBUM,
+                     BROWSE_ALBUMS, False, True, kids)
+
+    # ── Albums — Einträge eines Buchstabens ───────────────────────────────────
+    if media_content_id.startswith(f"albums_letter{S}"):
+        letter = media_content_id[len(f"albums_letter{S}"):]
+        data = await C.async_get("/library/albums?offset=0&limit=10000") or {}
+        filtered = [al for al in data.get("albums", []) if _first_letter(al["name"]) == letter]
         kids = [_node(f"{al['name']} — {al['artist']}" if al.get("artist") else al["name"],
                       MediaClass.ALBUM, MediaType.ALBUM,
                       f"album{S}{al['artist']}{S}{al['name']}", True, True,
@@ -72,9 +125,38 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
                                        f"{slugify(al['artist'] + '||' + al['name'])}.jpg",
                                        entity, MediaType.ALBUM,
                                        f"album{S}{slugify(al['artist'])}{S}{al['id']}"))
-                for al in data.get("albums", [])]
-        return _node("Albums", MediaClass.DIRECTORY, MediaType.ALBUM, BROWSE_ALBUMS, False, True, kids)
+                for al in filtered]
+        return _node(f"Albums — {letter}", MediaClass.DIRECTORY, MediaType.ALBUM,
+                     media_content_id, False, True, kids)
 
+    # ── Tracks — Buchstaben-Übersicht ─────────────────────────────────────────
+    if media_content_id == BROWSE_TRACKS:
+        data_all = await C.async_get("/library/tracks?limit=99999") or {}
+        buckets: dict[str, list] = {}
+        for t in data_all.get("tracks", []):
+            buckets.setdefault(_first_letter(t["name"]), []).append(t)
+        total = data_all.get("total", 0)
+        letters = sorted(l for l in buckets if l != '#') + (['#'] if '#' in buckets else [])
+        kids = [_node(f"{l} ({len(buckets[l])})", MediaClass.DIRECTORY, MediaType.TRACK,
+                      f"tracks_letter{S}{l}", False, True)
+                for l in letters]
+        return _node(f"Tracks ({total})", MediaClass.DIRECTORY, MediaType.TRACK,
+                     BROWSE_TRACKS, False, True, kids)
+
+    # ── Tracks — Einträge eines Buchstabens ───────────────────────────────────
+    if media_content_id.startswith(f"tracks_letter{S}"):
+        letter = media_content_id[len(f"tracks_letter{S}"):]
+        data = await C.async_get(f"/library/tracks?letter={quote(letter, safe='')}&limit=2000") or {}
+        kids = [_node(
+                    f"{t['name']} — {t['artist']}" if t.get("artist") else t["name"],
+                    MediaClass.TRACK, MediaType.TRACK,
+                    _track_cid(t, S), True, False,
+                    thumbnail=_track_thumb(t, hu, bu, entity, S))
+                for t in data.get("tracks", [])]
+        return _node(f"Tracks — {letter}", MediaClass.DIRECTORY, MediaType.TRACK,
+                     media_content_id, False, True, kids)
+
+    # ── Artist → seine Alben ──────────────────────────────────────────────────
     parts = media_content_id.split(S)
 
     if parts[0] == "artist" and len(parts) == 2:
@@ -82,13 +164,14 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
         an = data.get("artist", parts[1])
         kids = [_node(al["name"], MediaClass.ALBUM, MediaType.ALBUM,
                       f"album{S}{an}{S}{al['name']}", True, True,
-                      thumbnail=_thumb(hu, bu,
-                                       f"{slugify(an + '||' + al['name'])}.jpg",
+                      thumbnail=_thumb(hu, bu, f"{slugify(an + '||' + al['name'])}.jpg",
                                        entity, MediaType.ALBUM,
                                        f"album{S}{slugify(an)}{S}{al['id']}"))
                 for al in data.get("albums", [])]
-        return _node(an, MediaClass.ARTIST, MediaType.ARTIST, f"artist{S}{an}", False, True, kids)
+        return _node(an, MediaClass.ARTIST, MediaType.ARTIST,
+                     f"artist{S}{an}", False, True, kids)
 
+    # ── Album → seine Tracks ──────────────────────────────────────────────────
     if parts[0] == "album" and len(parts) == 3:
         data = await C.async_get(f"/library/albums/{q(parts[1])}/{q(parts[2])}/tracks") or {}
         kids = [_node(t["name"], MediaClass.TRACK, MediaType.TRACK,

--- a/custom_components/apple_music/const.py
+++ b/custom_components/apple_music/const.py
@@ -1,21 +1,16 @@
 """Constants for the Apple Music integration."""
-
 DOMAIN = "apple_music"
-
 CONF_HOST = "host"
 CONF_PORT = "port"
-
 DEFAULT_PORT = 8181
 DEFAULT_NAME = "Apple Music"
-
 # How often HA polls the server for state
 SCAN_INTERVAL_SECONDS = 5
-
 # Media browser node identifiers
 BROWSE_ROOT       = "root"
 BROWSE_PLAYLISTS  = "playlists"
 BROWSE_ARTISTS    = "artists"
 BROWSE_ALBUMS     = "albums"
-
+BROWSE_TRACKS     = "tracks"
 # Separator used in browse media_content_id paths
 BROWSE_SEP = "||"

--- a/custom_components/apple_music/media_player.py
+++ b/custom_components/apple_music/media_player.py
@@ -183,8 +183,6 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
         return r if r in ("off", "all", "one") else "off"
 
     # ── Progress tracking ─────────────────────────────────────────────────────
-    # HA uses media_position + media_position_updated_at to interpolate the
-    # progress bar live between polls — no need to update every second.
 
     @property
     def media_position(self) -> float | None:
@@ -223,7 +221,6 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
         await self.coordinator.async_send_command("PUT", "/stop")
 
     async def async_media_next_track(self) -> None:
-        # Optimistically clear track info so UI shows loading state instantly
         self._optimistic_state("playing")
         await self.coordinator.async_send_command("PUT", "/next")
 
@@ -233,7 +230,6 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     async def async_set_volume_level(self, volume: float) -> None:
         self._optimistic_volume = float(volume)
-        # Patch coordinator data immediately so polls don't snap the slider back
         if self.coordinator.data:
             self.coordinator.data = dict(self.coordinator.data)
             self.coordinator.data["volume"] = int(volume * 100)
@@ -276,12 +272,14 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
             )
             await self.coordinator.async_request_refresh()
             return
+
         elif parts[0] == "playlist" and len(parts) == 2:
             await self.coordinator.async_send_command(
                 "PUT", f"/playlists/{parts[1]}/play"
             )
             await self.coordinator.async_request_refresh()
             return
+
         elif parts[0] == "album" and len(parts) == 3:
             artist_id = parts[1]
             album_id  = parts[2]
@@ -291,23 +289,15 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
             )
             await self.coordinator.async_request_refresh()
             return
-        elif parts[0] == "track" and len(parts) == 2:
-            # Optimistically update state so UI feels instant
-            track_id = parts[1]
-            current = dict(self.coordinator.data or {})
-            current["player_state"] = "playing"
-            current["id"] = track_id
-            current["player_position"] = 0
-            current["position_timestamp"] = None
-            self.coordinator.async_set_updated_data(current)
 
-            # Fire command without blocking — notify.py will push the real state via SSE
-            self.hass.async_create_task(
-                self.coordinator.async_send_command(
-                    "PUT", f"/library/tracks/{track_id}/play"
-                )
+        elif parts[0] == "track" and len(parts) >= 2:
+            track_id = parts[1]
+            await self.coordinator.async_send_command(
+                "PUT", f"/library/tracks/{track_id}/play"
             )
+            await self.coordinator.async_request_refresh()
             return
+
         else:
             _LOGGER.warning("Unrecognised media_id for play_media: %s", media_id)
             return
@@ -400,8 +390,6 @@ class AirPlaySpeaker(CoordinatorEntity, MediaPlayerEntity):
         return AIRPLAY_FEATURES
 
     def _get_device_data(self) -> dict | None:
-        """Find this speaker's current data from the coordinator's airplay cache."""
-        # AirPlay state is fetched separately; we store it as extra data on the coordinator
         return getattr(self.coordinator, "_airplay_devices", {}).get(self._device_id)
 
     @property
@@ -470,7 +458,6 @@ class AirPlaySpeaker(CoordinatorEntity, MediaPlayerEntity):
     async def async_set_volume_level(self, volume: float) -> None:
         volume = float(volume)
         self._optimistic_volume = volume
-        # Patch the coordinator cache immediately so polls don't snap the slider back
         devices = getattr(self.coordinator, "_airplay_devices", {})
         if self._device_id in devices:
             devices[self._device_id] = dict(devices[self._device_id])

--- a/custom_components/apple_music/media_player.py
+++ b/custom_components/apple_music/media_player.py
@@ -8,10 +8,13 @@ from datetime import datetime, timezone
 
 from homeassistant.components.media_player import (
     BrowseMedia,
+    MediaClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
     MediaType,
+    SearchMedia,
+    SearchMediaQuery,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -45,6 +48,7 @@ MAIN_PLAYER_FEATURES = (
     | MediaPlayerEntityFeature.SEEK
     | MediaPlayerEntityFeature.PLAY_MEDIA
     | MediaPlayerEntityFeature.BROWSE_MEDIA
+    | MediaPlayerEntityFeature.SEARCH_MEDIA
 )
 
 # Features for AirPlay speaker entities
@@ -337,6 +341,98 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
             media_content_id or "root",
             self,
         )
+
+    # ── Search ───────────────────────────────────────────────────────────────
+    #
+    # Maps HA's SearchMediaQuery onto the server's /library/search endpoint
+    # (server/app.js), which returns track/artist/album/playlist matches.
+    # media_content_id values follow the exact same "type||..." convention used
+    # in browse_media.py / async_play_media() above, so search results play the
+    # same way browsed items do.
+    #
+    # Assumption: when media_filter_classes contains more than one class (or is
+    # unset), we ask the server for "all" categories rather than issuing several
+    # requests, since the server already does this in one pass.
+    # Edge case: an empty/whitespace-only search_query returns no results instead
+    # of hitting the server, mirroring the server's own 400 on a missing q param.
+    async def async_search_media(self, query: SearchMediaQuery) -> SearchMedia:
+        """Search the Apple Music library via the Mac server."""
+        search_query = (query.search_query or "").strip()
+        if not search_query:
+            return SearchMedia(result=[])
+
+        media_type_param = "all"
+        if query.media_filter_classes and len(query.media_filter_classes) == 1:
+            media_type_param = {
+                MediaClass.ARTIST: "artist",
+                MediaClass.ALBUM: "album",
+                MediaClass.TRACK: "track",
+                MediaClass.PLAYLIST: "playlist",
+            }.get(query.media_filter_classes[0], "all")
+
+        path = (
+            f"/library/search?q={urlquote(search_query, safe='')}"
+            f"&media_type={media_type_param}"
+        )
+        data = await self.coordinator.async_get(path) or {}
+
+        S = BROWSE_SEP
+        results: list[BrowseMedia] = []
+
+        for t in data.get("tracks", []) or []:
+            artist = t.get("albumArtist") or t.get("artist") or ""
+            album = t.get("album") or ""
+            title = f"{t.get('name', '')} — {artist}" if artist else t.get("name", "")
+            results.append(
+                BrowseMedia(
+                    title=title,
+                    media_class=MediaClass.TRACK,
+                    media_content_type=MediaType.TRACK,
+                    media_content_id=f"track{S}{t.get('id', '')}{S}{artist}{S}{album}",
+                    can_play=True,
+                    can_expand=False,
+                )
+            )
+
+        for a in data.get("artists", []) or []:
+            results.append(
+                BrowseMedia(
+                    title=a.get("name", ""),
+                    media_class=MediaClass.ARTIST,
+                    media_content_type=MediaType.ARTIST,
+                    media_content_id=f"artist{S}{a.get('name', '')}",
+                    can_play=True,
+                    can_expand=True,
+                )
+            )
+
+        for al in data.get("albums", []) or []:
+            artist = al.get("artist", "")
+            title = f"{al.get('name', '')} — {artist}" if artist else al.get("name", "")
+            results.append(
+                BrowseMedia(
+                    title=title,
+                    media_class=MediaClass.ALBUM,
+                    media_content_type=MediaType.ALBUM,
+                    media_content_id=f"album{S}{artist}{S}{al.get('name', '')}",
+                    can_play=True,
+                    can_expand=True,
+                )
+            )
+
+        for pl in data.get("playlists", []) or []:
+            results.append(
+                BrowseMedia(
+                    title=pl.get("name", ""),
+                    media_class=MediaClass.PLAYLIST,
+                    media_content_type=MediaType.PLAYLIST,
+                    media_content_id=f"playlist{S}{pl.get('id', '')}",
+                    can_play=True,
+                    can_expand=False,
+                )
+            )
+
+        return SearchMedia(result=results)
 
 
 def _map_airplay_kind(device_data: dict) -> str:

--- a/server/app.js
+++ b/server/app.js
@@ -314,6 +314,35 @@ function sendResponse(error, res) {
 var libraryCache = { tracks: null, fetchedAt: 0, ttl: 60 * 60 * 1000, pending: [] };
 var albumsCache  = null;
 var artistsCache = null;
+// Custom addition: short-lived playlist cache used only by the extended /library/search
+// endpoint below, so typing in YAMP's search box doesn't trigger an AppleScript exec per
+// keystroke. The existing /playlists route is left untouched and still fetches live.
+var playlistsCache = { data: null, fetchedAt: 0, ttl: 5 * 60 * 1000 };
+
+function getPlaylistsCached(callback) {
+  var now = Date.now();
+  if (playlistsCache.data && (now - playlistsCache.fetchedAt) < playlistsCache.ttl) {
+    return callback(null, playlistsCache.data);
+  }
+  var script = path.join(__dirname, 'lib', 'get-playlists.applescript');
+  execFile('osascript', [script], function(error, stdout) {
+    if (error) { return callback(error); }
+    var playlists = [];
+    var lines = (stdout || '').trim().split(/\r\n|\r|\n/);
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i].trim();
+      if (!line) { continue; }
+      var tab = line.indexOf('\t');
+      if (tab === -1) { continue; }
+      var id   = line.substring(0, tab).trim();
+      var name = line.substring(tab + 1).trim();
+      if (id && name) { playlists.push({ id: id, name: name }); }
+    }
+    playlistsCache.data      = playlists;
+    playlistsCache.fetchedAt = Date.now();
+    callback(null, playlists);
+  });
+}
 
 // SSE clients and push state
 var sseClients = [];
@@ -1208,15 +1237,73 @@ app.get('/library/search', function(req, res) {
   if (!query) {
     return res.status(400).json({ error: 'q parameter is required' });
   }
+  // Custom addition: optional media_type filter ('all' | 'track' | 'artist' | 'album' |
+  // 'playlist') and a per-category limit, so callers (e.g. HA's media_player.search_media)
+  // can narrow the request the way YAMP's media-type chips expect. Defaults preserve the
+  // previous track-only behaviour shape, just with the extra (empty) keys added.
+  var mediaType = (req.query.media_type || 'all').toLowerCase();
+  var limit = parseInt(req.query.limit) || 50;
+  var wantTracks    = mediaType === 'all' || mediaType === 'track';
+  var wantArtists   = mediaType === 'all' || mediaType === 'artist';
+  var wantAlbums    = mediaType === 'all' || mediaType === 'album';
+  var wantPlaylists = mediaType === 'all' || mediaType === 'playlist';
+
   getLibraryTracks(function(error, tracks) {
     if (error) { console.log(error); return res.sendStatus(500); }
-    var results = [];
-    for (var i = 0; i < tracks.length && results.length < 50; i++) {
-      var t = tracks[i];
-      if ((t.name || '').toLowerCase().indexOf(query) === -1) { continue; }
-      results.push({ id: t.id, name: t.name, artist: t.artist, album: t.album });
+
+    var trackResults = [];
+    if (wantTracks) {
+      for (var i = 0; i < tracks.length && trackResults.length < limit; i++) {
+        var t = tracks[i];
+        if ((t.name || '').toLowerCase().indexOf(query) === -1) { continue; }
+        trackResults.push({
+          id: t.id, name: t.name, artist: t.artist, album: t.album,
+          albumArtist: t.albumArtist
+        });
+      }
     }
-    res.json({ query: query, tracks: results });
+
+    var artistResults = [];
+    if (wantArtists) {
+      if (!artistsCache) { artistsCache = buildArtists(tracks, 0, 999999); }
+      artistResults = artistsCache.artists
+        .filter(function(a) { return a.name.toLowerCase().indexOf(query) !== -1; })
+        .slice(0, limit);
+    }
+
+    var albumResults = [];
+    if (wantAlbums) {
+      if (!albumsCache) { albumsCache = buildAlbums(tracks, 0, 999999); }
+      albumResults = albumsCache.albums
+        .filter(function(al) { return al.name.toLowerCase().indexOf(query) !== -1; })
+        .slice(0, limit);
+    }
+
+    function sendResults(playlists) {
+      var playlistResults = wantPlaylists
+        ? playlists.filter(function(pl) { return pl.name.toLowerCase().indexOf(query) !== -1; }).slice(0, limit)
+        : [];
+      res.json({
+        query: query,
+        tracks: trackResults,
+        artists: artistResults,
+        albums: albumResults,
+        playlists: playlistResults
+      });
+    }
+
+    if (wantPlaylists) {
+      getPlaylistsCached(function(plError, playlists) {
+        if (plError) {
+          // Degrade gracefully: a playlist-fetch failure shouldn't fail the whole search
+          console.log('playlist search error:', plError);
+          return sendResults([]);
+        }
+        sendResults(playlists);
+      });
+    } else {
+      sendResults([]);
+    }
   });
 });
 

--- a/server/app.js
+++ b/server/app.js
@@ -1268,6 +1268,33 @@ process.on('unhandledRejection', function(reason) {
   console.error('[unhandledRejection] Server kept alive:', reason);
 });
 
+app.get('/library/tracks', function(req, res) {
+  var offset = parseInt(req.query.offset) || 0;
+  var limit  = parseInt(req.query.limit)  || 100;
+  var letter = (req.query.letter || '').toUpperCase();
+  getLibraryTracks(function(error, tracks) {
+    if (error) { console.log(error); return res.sendStatus(500); }
+    var filtered = tracks;
+    if (letter) {
+      filtered = tracks.filter(function(t) {
+        if (!t.name) { return letter === '#'; }
+        var c = t.name.trim()[0].toUpperCase();
+        return letter === '#' ? !/[A-Z]/.test(c) : c === letter;
+      });
+    }
+    var sorted = filtered.slice().sort(function(a, b) {
+      return (a.name || '').toLowerCase().localeCompare((b.name || '').toLowerCase());
+    });
+    res.json({
+      total:  sorted.length,
+      offset: offset,
+      limit:  limit,
+      letter: letter || null,
+      tracks: sorted.slice(offset, offset + limit)
+    });
+  });
+});
+
 app.listen(process.env.PORT || 8181);
 
 getLibraryTracks(function(error, tracks) {


### PR DESCRIPTION
## Add native search support (`media_player.search_media`) + fix compilation album grouping

### Summary

This PR adds two related improvements to the Apple Music integration:

1. **`async_search_media()` support** – the entity now implements Home Assistant's standard `media_player.search_media` action, so frontend cards (e.g. media browser, YAMP) can search the library directly instead of relying on `browse_media` alone.
2. **Compilation album grouping fix** – albums tagged as a compilation in Music.app are now grouped under a single `"Various Artists"` entry instead of fragmenting into multiple entries (one per differing per-track artist tag).

### 1. Search support

**Server (`server/app.js`)**
- Extended `/library/search` (previously track-name-only, max 50 results) to also match against artist, album, and playlist names.
- New optional query params:
  - `media_type` (`all` | `track` | `artist` | `album` | `playlist`, default `all`)
  - `limit` (per category, default 50)
- Response shape is backward compatible: existing `query` / `tracks` keys unchanged, new `artists` / `albums` / `playlists` keys added.
- Added a 5-minute in-memory playlist cache (`getPlaylistsCached`) used only by this endpoint, so typing in a search box doesn't trigger an AppleScript exec per keystroke. The existing `/playlists` route is untouched and still fetches live.

**Integration (`custom_components/apple_music/media_player.py`)**
- Added `MediaPlayerEntityFeature.SEARCH_MEDIA` to the main player's feature flags.
- Implemented `async_search_media(query: SearchMediaQuery) -> SearchMedia`, which:
  - Maps a single-element `media_filter_classes` to the server's `media_type` param (falls back to `all` for empty/multi-class filters).
  - Builds `BrowseMedia` results using the exact same `media_content_id` conventions as `browse_media.py` (`track||id||artist||album`, `album||artist||album`, `artist||name`, `playlist||id`), so search results play back through the existing `async_play_media()` parser without any changes there.
  - Returns an empty result set for an empty/whitespace-only query rather than hitting the server (mirrors the server's own 400 on a missing `q` param).

**Known limitation:** search results currently have no artwork thumbnail (unlike the browse hierarchy, which derives thumbnails via `_track_thumb()`/`_thumb()`). Not addressed in this PR — flagging as a possible follow-up.

### 2. Compilation album grouping

**Problem:** `buildAlbums()` grouped albums by `artist + "||" + name`, where `artist` falls back through `albumArtist → artist`. For compilation albums with inconsistently tagged `albumArtist` per track, this produced one album entry per distinct artist tag (e.g. the same compilation showing up 8 times under 8 different artists).

**Fix:**
- `FETCH_TRACKS_SCRIPT` (both the bulk JXA path and the per-track fallback path) now also reads Music.app's native `compilation` boolean property per track.
- `buildAlbums()`: tracks with `compilation === true` are grouped by album name only, displayed as `"Various Artists"` (`VARIOUS_ARTISTS` constant).
- New shared helper `matchesAlbumArtist(track, artistName)`, used by:
  - `GET /library/albums/:artist/:album/tracks`
  - `PUT /library/albums/:artist/:album/play`

  Without this, "Various Artists" would show up correctly in listings but resolve to 0 tracks / 404 on tap, since no individual track literally has `albumArtist === "Various Artists"`.

**Explicitly out of scope (by design, not an oversight):**
- Artist browsing/search (`buildAlbumsByArtist()`, `/library/artists/:artist/tracks`) is unchanged — a track's appearance on a compilation still correctly shows up under that track's own artist page.
- No heuristic fallback for libraries where the `compilation` flag isn't reliably tagged (e.g. detecting "same album name, multiple artists" automatically). Only the real Music.app flag is honored. If your library has untagged compilations, they'll still fragment as before.

### Testing performed

All manual, via Developer Tools → Actions in Home Assistant against a live library:
- `media_player.search_media` with `media_filter_classes` unset and set to each of `track`, `artist`, `album`, `playlist` individually — confirmed correct, correctly-typed results for each.
- `media_player.play_media` with a track result's `media_content_id` — confirmed playback.
- `media_player.play_media` with an artist result's `media_content_id` — confirmed playback.
- `media_player.play_media` with a compilation album's `media_content_id` (`album||Various Artists||<name>`) — confirmed full album playback.
- Verified previously-fragmented compilation album ("25 Legendary Vocal Jazz Ballads", 8 entries) now appears as a single `Various Artists` entry in search results.

### Notes for reviewers

- No changes to `browse_media.py`, `__init__.py`, `const.py`, or `config_flow.py`.
- The library cache (`libraryCache`, 1h TTL) needs a refresh (or a server restart) to pick up the new `compilation` field on tracks fetched before this change.