### PR TITLE
Genre browsing & search, per receiver reconnect

### DIFF
--- a/am-search-card.js
+++ b/am-search-card.js
@@ -17,6 +17,7 @@ const FILTERS = [
   { id: 'track',    label: 'Track',     classes: ['track'] },
   { id: 'album',    label: 'Album',     classes: ['album'] },
   { id: 'artist',   label: 'Künstler',  classes: ['artist'] },
+  { id: 'genre',    label: 'Genre',     classes: ['genre'] },
   { id: 'playlist', label: 'Playlist',  classes: ['playlist'] },
 ];
 
@@ -25,10 +26,12 @@ const MEDIA_ICONS = {
   album:    'mdi:album',
   artist:   'mdi:account-music',
   playlist: 'mdi:playlist-music',
+  genre:    'mdi:tag-multiple',
 };
 
 const MEDIA_LABELS = {
   track: 'Track', album: 'Album', artist: 'Künstler', playlist: 'Playlist',
+  genre: 'Genre',
 };
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -189,9 +192,7 @@ class AmSearchCard extends HTMLElement {
       clearTimeout(this._debounce);
       // Gleiche Logik wie beim Leeren per Tastatur: bei aktivem Playlist-Filter
       // die vollstaendige Playlist-Liste zeigen statt eine leere Ansicht.
-      if (this._filter === 'playlist') {
-        this._loadAllPlaylists();
-      } else {
+      if (!this._loadAllForFilter()) {
         this._navStack = [];
         this._renderView();
       }
@@ -203,9 +204,7 @@ class AmSearchCard extends HTMLElement {
       clearTimeout(this._debounce);
       const q = input.value.trim();
       if (!q) {
-        if (this._filter === 'playlist') {
-          this._loadAllPlaylists();
-        } else {
+        if (!this._loadAllForFilter()) {
           this._navStack = [];
           this._renderView();
         }
@@ -241,9 +240,7 @@ class AmSearchCard extends HTMLElement {
         const q = input.value.trim();
         if (q) {
           this._doSearch(q);
-        } else if (this._filter === 'playlist') {
-          this._loadAllPlaylists();
-        } else {
+        } else if (!this._loadAllForFilter()) {
           this._navStack = [];
           this._renderView();
         }
@@ -458,6 +455,9 @@ class AmSearchCard extends HTMLElement {
       list.innerHTML = available.map(e => `<label class="am-player-item" title="${displayName(e)}">
         <input type="checkbox" data-entity="${e}"/>
         <span style="overflow:hidden;text-overflow:ellipsis">${displayName(e)}</span>
+        <button class="am-reconnect" data-entity="${e}" title="Neu verbinden">
+          <ha-icon icon="mdi:refresh"></ha-icon>
+        </button>
       </label>`).join('');
 
       list.querySelectorAll('input[type="checkbox"]').forEach(cb => {
@@ -465,6 +465,23 @@ class AmSearchCard extends HTMLElement {
           ev.stopPropagation();
           this._hass.callService('media_player', cb.checked ? 'turn_on' : 'turn_off',
             { entity_id: cb.dataset.entity });
+        });
+      });
+
+      // Neu verbinden: aus, kurz warten, wieder ein. Der Knopf liegt in einem
+      // <label>, daher muss dessen Standardaktion unterbunden werden – sonst
+      // wuerde zusaetzlich das Kontrollkaestchen umschalten.
+      list.querySelectorAll('.am-reconnect').forEach(btn => {
+        btn.addEventListener('click', (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          const entity = btn.dataset.entity;
+          btn.classList.add('busy');
+          this._hass?.callService('media_player', 'turn_off', { entity_id: entity });
+          setTimeout(() => {
+            this._hass?.callService('media_player', 'turn_on', { entity_id: entity });
+            btn.classList.remove('busy');
+          }, 2000);
         });
       });
     }
@@ -618,6 +635,7 @@ class AmSearchCard extends HTMLElement {
       if (parts[0] === 'album')    return parts[3] !== 'music video'; // album||artist||name||mediaKind
       if (parts[0] === 'playlist') return parts[2] !== 'music video'; // playlist||id||mediaKind
       if (parts[0] === 'artist')   return parts[2] !== 'music video'; // artist||name||mediaKind
+      if (parts[0] === 'genre')    return parts[2] !== 'music video'; // genre||name||mediaKind
       return true;
     });
   }
@@ -744,6 +762,35 @@ class AmSearchCard extends HTMLElement {
 
   // ── Alle Playlists laden (wenn Filter=Playlist ohne Sucheingabe) ─────────────
 
+  // Zeigt bei leerem Suchfeld die vollstaendige Liste – fuer Playlists und Genres
+  _loadAllForFilter() {
+    if (this._filter === 'playlist') { this._loadAllPlaylists(); return true; }
+    if (this._filter === 'genre')    { this._loadAllGenres();    return true; }
+    return false;
+  }
+
+  async _loadAllGenres() {
+    this._loading = true;
+    this._error   = '';
+    this._renderLoading();
+    try {
+      const res = await this._hass.connection.sendMessagePromise({
+        type:               'media_player/browse_media',
+        entity_id:          this._config.entity,
+        media_content_type: 'genre',
+        media_content_id:   'genres',
+      });
+      const items = res?.children ?? [];
+      this._navStack = [{ title: 'Genres', items }];
+      this._renderView();
+    } catch (e) {
+      this._error = 'Genres konnten nicht geladen werden: ' + (e?.message ?? e);
+      this._renderError();
+    } finally {
+      this._loading = false;
+    }
+  }
+
   async _loadAllPlaylists() {
     this._loading = true;
     this._error   = '';
@@ -867,7 +914,8 @@ class AmSearchCard extends HTMLElement {
     // Phase 2: Artists/Alben sequenziell expandieren → Album-Reihenfolge erhalten
     const expandable = filteredItems.filter(i =>
       String(i.media_content_id).startsWith('artist||') ||
-      String(i.media_content_id).startsWith('album||')
+      String(i.media_content_id).startsWith('album||') ||
+      String(i.media_content_id).startsWith('genre||')
     );
 
     if (expandable.length > 0) {
@@ -876,6 +924,7 @@ class AmSearchCard extends HTMLElement {
         try {
           const res = await browse(item);
           const children = res?.children ?? [];
+          // Genre und Album liefern direkt Tracks, nur Artist braucht zwei Ebenen
           if (String(item.media_content_id).startsWith('artist||')) {
             // Artist → sequenziell Album für Album expandieren
             for (const album of children) {
@@ -1250,6 +1299,15 @@ const CSS_STYLES = `
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .am-player-item:hover { background: rgba(255,255,255,.08); }
+  .am-reconnect {
+    margin-left: auto; flex-shrink: 0;
+    background: none; border: none; padding: 0 2px; cursor: pointer;
+    color: rgba(240,240,240,.4); --mdc-icon-size: 16px;
+    display: flex; align-items: center;
+  }
+  .am-reconnect:hover { color: #ffffff; }
+  .am-reconnect.busy { color: #fc3c44; animation: am-spin 1s linear infinite; }
+  @keyframes am-spin { to { transform: rotate(360deg); } }
   .am-player-item input[type="checkbox"] {
     accent-color: #fc3c44; cursor: pointer; width: 16px; height: 16px; flex-shrink: 0;
   }

--- a/custom_components/apple_music/browse_media.py
+++ b/custom_components/apple_music/browse_media.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 from homeassistant.components.media_player import BrowseMedia, MediaClass, MediaType
 from homeassistant.components.media_player.errors import BrowseError
 from .const import (
-    BROWSE_ALBUMS, BROWSE_ARTISTS, BROWSE_PLAYLISTS,
+    BROWSE_ALBUMS, BROWSE_ARTISTS, BROWSE_GENRES, BROWSE_PLAYLISTS,
     BROWSE_ROOT, BROWSE_SEP, BROWSE_TRACKS,
 )
 
@@ -60,6 +60,7 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
             _node("Artists",   MediaClass.ARTIST,   MediaType.ARTIST,   BROWSE_ARTISTS,   False, True),
             _node("Albums",    MediaClass.ALBUM,     MediaType.ALBUM,    BROWSE_ALBUMS,    False, True),
             _node("Tracks",    MediaClass.TRACK,     MediaType.TRACK,    BROWSE_TRACKS,    False, True),
+            _node("Genres",    MediaClass.GENRE,     MediaType.GENRE,    BROWSE_GENRES,    False, True),
         ])
 
     # ── Playlists ─────────────────────────────────────────────────────────────
@@ -74,6 +75,15 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
                 for pl in data.get("playlists", [])]
         return _node("Playlists", MediaClass.DIRECTORY, MediaType.PLAYLIST,
                      BROWSE_PLAYLISTS, False, True, kids)
+
+    # ── Genres ────────────────────────────────────────────────────────────────
+    if media_content_id == BROWSE_GENRES:
+        data = await C.async_get("/library/genres") or {}
+        kids = [_node(f"{g['name']} ({g['count']})", MediaClass.GENRE, MediaType.GENRE,
+                      f"genre{S}{g['name']}{S}{g.get('mediaKind','song')}", True, True)
+                for g in data.get("genres", [])]
+        return _node("Genres", MediaClass.DIRECTORY, MediaType.GENRE,
+                     BROWSE_GENRES, False, True, kids)
 
     # ── Artists — Buchstaben-Übersicht ────────────────────────────────────────
     if media_content_id == BROWSE_ARTISTS:
@@ -185,6 +195,18 @@ async def async_browse_media(coordinator, media_content_type, media_content_id, 
                      f"album{S}{parts[1]}{S}{parts[2]}", False, True, kids)  # parts[3]=mediaKind ignoriert beim Drill-down
 
     # ── Playlist → ihre Tracks ───────────────────────────────────────────────
+    if parts[0] == "genre" and len(parts) >= 2:
+        g_name = parts[1]
+        data   = await C.async_get(f"/library/genres/{q(g_name)}/tracks") or {}
+        kids   = [_node(
+                    f"{t['name']} — {t.get('albumArtist') or t.get('artist') or ''}".rstrip(" — "),
+                    MediaClass.TRACK, MediaType.TRACK,
+                    _track_cid(t, S), True, False,
+                    thumbnail=_track_thumb(t, hu, bu, entity, S))
+                  for t in data.get("tracks", [])]
+        return _node(data.get("genre", g_name), MediaClass.GENRE, MediaType.GENRE,
+                     f"genre{S}{g_name}", False, True, kids)
+
     if parts[0] == "playlist" and len(parts) >= 2:
         pl_id = parts[1]
         data  = await C.async_get(f"/playlists/{q(pl_id)}/tracks") or {}

--- a/custom_components/apple_music/const.py
+++ b/custom_components/apple_music/const.py
@@ -12,5 +12,6 @@ BROWSE_PLAYLISTS  = "playlists"
 BROWSE_ARTISTS    = "artists"
 BROWSE_ALBUMS     = "albums"
 BROWSE_TRACKS     = "tracks"
+BROWSE_GENRES     = "genres"
 # Separator used in browse media_content_id paths
 BROWSE_SEP = "||"

--- a/custom_components/apple_music/media_player.py
+++ b/custom_components/apple_music/media_player.py
@@ -305,6 +305,15 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
             await self.coordinator.async_request_refresh()
             return
 
+        elif parts[0] == "genre" and len(parts) >= 2:
+            genre = parts[1]
+            _LOGGER.debug("Playing genre: %s", genre)
+            await self.coordinator.async_send_command(
+                "PUT", f"/library/genres/{urlquote(genre, safe='')}/play"
+            )
+            await self.coordinator.async_request_refresh()
+            return
+
         elif parts[0] == "playlist" and len(parts) >= 2:
             await self.coordinator.async_send_command(
                 "PUT", f"/playlists/{parts[1]}/play"
@@ -507,6 +516,21 @@ class AppleMusicPlayer(CoordinatorEntity, MediaPlayerEntity):
                     can_play=True,
                     can_expand=True,
                     thumbnail=thumbnail,
+                )
+            )
+
+        for g in data.get("genres", []) or []:
+            g_name = g.get("name", "")
+            g_mk   = g.get("mediaKind", "song")
+            cid    = f"genre{S}{g_name}{S}{g_mk}"
+            results.append(
+                BrowseMedia(
+                    title=g_name,
+                    media_class=MediaClass.GENRE,
+                    media_content_type=MediaType.GENRE,
+                    media_content_id=cid,
+                    can_play=True,
+                    can_expand=True,
                 )
             )
 

--- a/server/app.js
+++ b/server/app.js
@@ -157,13 +157,14 @@ var FETCH_TRACKS_SCRIPT = [
   '  var allDiscNums = lib.tracks.discNumber();',
   '  var allDurations = lib.tracks.duration();',
   '  var allMediaKinds = lib.tracks.mediaKind();',
+  '  var allGenres = lib.tracks.genre();',
   '  var allCompilations = lib.tracks.compilation();',
   '  for (var i = 0; i < allIDs.length; i++) {',
   '    var kind = allKinds[i] || "";',
   '    if (kind !== "song" && kind !== "music video" && kind !== "" && kind !== undefined) { continue; }',
   '    var id = allIDs[i] || "";',
   '    if (!id) { continue; }',
-  '    tracks.push({ id: id, name: allNames[i] || "", artist: allArtists[i] || "", albumArtist: allAlbumArtists[i] || "", album: allAlbums[i] || "", track_number: allTrackNums[i] || 0, disc_number: allDiscNums[i] || 1, duration: allDurations[i] || 0, compilation: allCompilations[i] === true, mediaKind: allMediaKinds[i] || "song" });',
+  '    tracks.push({ id: id, name: allNames[i] || "", artist: allArtists[i] || "", albumArtist: allAlbumArtists[i] || "", album: allAlbums[i] || "", track_number: allTrackNums[i] || 0, disc_number: allDiscNums[i] || 1, duration: allDurations[i] || 0, compilation: allCompilations[i] === true, mediaKind: allMediaKinds[i] || "song", genre: allGenres[i] || "" });',
   '  }',
   '} catch(bulkErr) {',
   '  try {',
@@ -175,7 +176,7 @@ var FETCH_TRACKS_SCRIPT = [
   '        if (kind !== "song" && kind !== "music video" && kind !== "" && kind !== undefined) { continue; }',
   '        var id = ""; try { id = t.persistentID(); } catch(e) {}',
   '        if (!id) { continue; }',
-  '        tracks.push({ id: id, name: (function(){ try { return t.name() || ""; } catch(e) { return ""; } })(), artist: (function(){ try { return t.artist() || ""; } catch(e) { return ""; } })(), albumArtist: (function(){ try { return t.albumArtist() || ""; } catch(e) { return ""; } })(), album: (function(){ try { return t.album() || ""; } catch(e) { return ""; } })(), track_number: (function(){ try { return t.trackNumber(); } catch(e) { return 0; } })(), disc_number: (function(){ try { return t.discNumber(); } catch(e) { return 1; } })(), duration: (function(){ try { return t.duration(); } catch(e) { return 0; } })(), compilation: (function(){ try { return t.compilation() === true; } catch(e) { return false; } })(), mediaKind: (function(){ try { return t.mediaKind() || "song"; } catch(e) { return "song"; } })() });',
+  '        tracks.push({ id: id, name: (function(){ try { return t.name() || ""; } catch(e) { return ""; } })(), artist: (function(){ try { return t.artist() || ""; } catch(e) { return ""; } })(), albumArtist: (function(){ try { return t.albumArtist() || ""; } catch(e) { return ""; } })(), album: (function(){ try { return t.album() || ""; } catch(e) { return ""; } })(), track_number: (function(){ try { return t.trackNumber(); } catch(e) { return 0; } })(), disc_number: (function(){ try { return t.discNumber(); } catch(e) { return 1; } })(), duration: (function(){ try { return t.duration(); } catch(e) { return 0; } })(), compilation: (function(){ try { return t.compilation() === true; } catch(e) { return false; } })(), mediaKind: (function(){ try { return t.mediaKind() || "song"; } catch(e) { return "song"; } })(), genre: (function(){ try { return t.genre() || ""; } catch(e) { return ""; } })() });',
   '      } catch(e) {}',
   '    }',
   '  } catch(e) {}',
@@ -457,6 +458,26 @@ function buildArtists(tracks, offset, limit) {
   }
   artists.sort(function(a, b) { return a.name.toLowerCase().localeCompare(b.name.toLowerCase()); });
   return { total: artists.length, offset: offset, limit: limit, artists: artists.slice(offset, offset + limit) };
+}
+
+function buildGenres(tracks) {
+  var counts = {};
+  var kinds  = {};
+  for (var i = 0; i < tracks.length; i++) {
+    var g = (tracks[i].genre || '').trim();
+    if (!g) { continue; }
+    counts[g] = (counts[g] || 0) + 1;
+    if (!kinds[g]) kinds[g] = [];
+    kinds[g].push(tracks[i].mediaKind || 'song');
+  }
+  var genres = Object.keys(counts).map(function(g) {
+    var all = kinds[g] || [];
+    var allVideos = all.length > 0 && all.every(function(k) { return k === 'music video'; });
+    return { id: slugify(g), name: g, count: counts[g],
+             mediaKind: allVideos ? 'music video' : 'song' };
+  });
+  genres.sort(function(a, b) { return a.name.toLowerCase().localeCompare(b.name.toLowerCase()); });
+  return { total: genres.length, genres: genres };
 }
 
 function buildAlbumsByArtist(tracks, artistName) {
@@ -1200,6 +1221,34 @@ app.get('/library/artists', function(req, res) {
   });
 });
 
+app.get('/library/genres', function(req, res) {
+  getLibraryTracks(function(error, tracks) {
+    if (error) { console.log(error); return res.sendStatus(500); }
+    res.json(buildGenres(tracks));
+  });
+});
+
+// Tracks eines Genres, sortiert nach Album/Disc/Track wie die uebrigen Listen
+app.get('/library/genres/:genre/tracks', function(req, res) {
+  getLibraryTracks(function(error, tracks) {
+    if (error) { console.log(error); return res.sendStatus(500); }
+    var want = String(req.params.genre || '').toLowerCase();
+    var hits = tracks.filter(function(t) {
+      return (t.genre || '').toLowerCase() === want;
+    });
+    hits.sort(function(a, b) {
+      var byAlbum = String(a.album || '').toLowerCase()
+        .localeCompare(String(b.album || '').toLowerCase());
+      if (byAlbum !== 0) { return byAlbum; }
+      if ((a.disc_number || 1) !== (b.disc_number || 1)) {
+        return (a.disc_number || 1) - (b.disc_number || 1);
+      }
+      return (a.track_number || 0) - (b.track_number || 0);
+    });
+    res.json({ genre: req.params.genre, tracks: hits });
+  });
+});
+
 app.get('/library/artists/:artist/albums', function(req, res) {
   getLibraryTracks(function(error, tracks) {
     if (error) { console.log(error); return res.sendStatus(500); }
@@ -1319,6 +1368,28 @@ app.put('/library/albums/:artist/:album/play', function(req, res) {
     if (ids.length === 0) { return res.sendStatus(404); }
     playByIDsTempScript('HA_Play_Album', ids, function(error) {
       if (error) { console.log('play-album error:', error); return res.sendStatus(500); }
+      sendResponse(null, res);
+    });
+  });
+});
+
+app.put('/library/genres/:genre/play', function(req, res) {
+  var want = String(req.params.genre || '').toLowerCase();
+  getLibraryTracks(function(error, tracks) {
+    if (error) { return res.sendStatus(500); }
+    var ids = tracks
+      .filter(function(t) { return (t.genre || '').toLowerCase() === want; })
+      .sort(function(a, b) {
+        if (a.album < b.album) { return -1; }
+        if (a.album > b.album) { return 1; }
+        var ka = (a.disc_number || 1) * 10000 + (a.track_number || 0);
+        var kb = (b.disc_number || 1) * 10000 + (b.track_number || 0);
+        return ka - kb;
+      })
+      .map(function(t) { return t.id; });
+    if (ids.length === 0) { return res.sendStatus(404); }
+    playByIDsTempScript('HA_Play_Genre', ids, function(error) {
+      if (error) { console.log('play-genre error:', error); return res.sendStatus(500); }
       sendResponse(null, res);
     });
   });
@@ -1450,6 +1521,7 @@ app.get('/library/search', function(req, res) {
   var wantArtists   = mediaType === 'all' || mediaType === 'artist';
   var wantAlbums    = mediaType === 'all' || mediaType === 'album';
   var wantPlaylists = mediaType === 'all' || mediaType === 'playlist';
+  var wantGenres    = mediaType === 'all' || mediaType === 'genre';
 
   getLibraryTracks(function(error, tracks) {
     if (error) { console.log(error); return res.sendStatus(500); }
@@ -1516,6 +1588,13 @@ app.get('/library/search', function(req, res) {
         .slice(0, limit);
     }
 
+    var genreResults = [];
+    if (wantGenres) {
+      genreResults = buildGenres(tracks).genres
+        .filter(function(g) { return g.name.toLowerCase().indexOf(query) !== -1; })
+        .slice(0, limit);
+    }
+
     function sendResults(playlists) {
       var playlistResults = wantPlaylists
         ? playlists.filter(function(pl) { return pl.name.toLowerCase().indexOf(query) !== -1; }).slice(0, limit)
@@ -1525,7 +1604,8 @@ app.get('/library/search', function(req, res) {
         tracks: trackResults,
         artists: artistResults,
         albums: albumResults,
-        playlists: playlistResults
+        playlists: playlistResults,
+        genres: genreResults
       });
     }
 


### PR DESCRIPTION
## Genre support

Genre was not captured anywhere, so it runs through the whole chain.

**Server** — `genre` is added to the track cache (bulk fetch and per-track fallback).
New endpoints:

- `GET /library/genres` — all genres with track count and `mediaKind`
- `GET /library/genres/:genre/tracks` — tracks of a genre, sorted by album/disc/track
- `PUT /library/genres/:genre/play` — plays a genre via the `HA_Play_Genre` helper playlist

Search now returns genres as a fourth result type.

**Integration** — `BROWSE_GENRES` constant, a Genres node in the browse tree with per-genre
track counts, resolution of a genre to its tracks, playback of `genre||name`, and genres in
search results.

**Card** — a new "Genre" filter chip. With an empty search field it shows the full genre list,
mirroring the existing playlist behaviour; the three places that handled this individually now
share one helper. The music-video filter covers genres, and "play all" expands them like albums.

A genre is only flagged as a video genre when *all* of its tracks are music videos.

## Per-receiver reconnect

AirPlay receivers occasionally stop producing sound while still reporting as connected. The only
reliable remedy is switching them off, waiting, and switching them back on. Each entry in the
receiver list now has a refresh button that does exactly this — off, two seconds, on — with a
spinner while it runs. The button suppresses the surrounding label's default action so it does
not toggle the checkbox as well.

This is a manual fallback: automatic recovery was attempted and did not work reliably.
